### PR TITLE
Sync develop with release v0.1.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Fixed
+
+### Changed
+
+### Removed
+
+## [0.1.0-alpha.2] - 2025-05-09 
+
+### Added
+
 - Added merge strategy guidelines for different branch types by @marcoluzi in #4
 - Added release notes formatting guidelines by @marcoluzi in #4
 - Add package metadata and license information to composer.json by @marcoluzi in #5
@@ -39,5 +49,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-[unreleased]: https://github.com/webkinder/sproutset/compare/v0.1.0-alpha.1...develop
+[unreleased]: https://github.com/webkinder/sproutset/compare/v0.1.0-alpha.2...develop
+[0.1.0-alpha.2]: https://github.com/webkinder/sproutset/releases/tag/v0.1.0-alpha.2
 [0.1.0-alpha.1]: https://github.com/webkinder/sproutset/releases/tag/v0.1.0-alpha.1


### PR DESCRIPTION
## Description
Synchronize develop branch with release v0.1.0-alpha.2 changes

## Related Issue
N/A - Release sync

## Branch Type and Merge Strategy
- [ ] Feature branch → develop (Will use squash/rebase merge)
- [x] Release branch → main and develop (Will use --no-ff merge commit)
- [ ] Hotfix branch → main and develop (Will use --no-ff merge commit)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Checklist
- [x] My code follows the project's coding standards
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] I have updated the changelog
- [x] I have checked for and resolved any merge conflicts
- [x] I have confirmed the correct merge strategy will be used (see Branch Type above)

## Additional Context
This PR syncs the following changes from release v0.1.0-alpha.2:
- Merge strategy guidelines
- Release notes formatting
- Package metadata updates

No additional changes needed - this is a straight sync from the release branch.