### PR TITLE
Updating wordpress to v7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- WordPress 7.0 update by @marcoluzi in #241
+
 ### Removed
 
 ## [v0.1.0-beta.10] - 2026-03-10

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Modern responsive image management for projects using the Roots Acorn framework.
 
 - PHP ^8.2
 - Roots Acorn ^5.0
-- WordPress ^5.9 || ^6.0
+- WordPress ^5.9 || ^6.0 || ^7.0
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "require": {
     "php": "^8.3",
     "roots/acorn": "^6.0",
-    "roots/wordpress-no-content": "^5.9 || ^6.0",
+    "roots/wordpress-no-content": "^5.9 || ^6.0 || ^7.0",
     "spatie/image": "^3.8",
     "spatie/image-optimizer": "^1.8"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ea94a89ff3a9e223032fcfe01dc5cbc0",
+    "content-hash": "efe2183cbeb757b348b6d0476f17024d",
     "packages": [
         {
             "name": "brick/math",
@@ -4085,23 +4085,23 @@
         },
         {
             "name": "roots/wordpress-no-content",
-            "version": "6.9.4",
+            "version": "7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress.git",
-                "reference": "6.9.4"
+                "reference": "7.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.w.org/release/wordpress-6.9.4-no-content.zip",
-                "reference": "6.9.4",
-                "shasum": "8ae812bb54223ef859cd3de37f1c6b1db20e0e6f"
+                "url": "https://downloads.w.org/release/wordpress-7.0-no-content.zip",
+                "reference": "7.0",
+                "shasum": "2ffdd31a747f68e3e5633064993997a7ce881975"
             },
             "require": {
-                "php": ">= 7.2.24"
+                "php": ">= 7.4"
             },
             "provide": {
-                "wordpress/core-implementation": "6.9.4"
+                "wordpress/core-implementation": "7.0"
             },
             "suggest": {
                 "ext-curl": "Performs remote request operations.",
@@ -4152,7 +4152,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-03-11T15:49:55+00:00"
+            "time": "2026-05-20T18:34:28+00:00"
         },
         {
             "name": "spatie/image",


### PR DESCRIPTION
## Description

Updated WordPress core dependency from version 6.9.4 to 7.0 to maintain compatibility with the latest WordPress release. This change updates the roots/wordpress-no-content package constraint in composer.json to allow WordPress 7.0 and updates the locked version in composer.lock.

## Branch Type and Merge Strategy

<!-- Put an `x` in the box that applies -->

- [x] Feature branch → develop (Will use squash merge)
- [ ] Release branch → main (Will use --no-ff merge commit)
- [ ] Hotfix branch → main and develop (Will use --no-ff merge commit)
- [ ] Main branch → develop (Will use --no-ff merge commit)

## Type of Change

<!-- Put an `x` in all the boxes that apply -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Release
- [x] Other

## Checklist

<!-- Put an `x` in all the boxes that apply -->

- [x] My code follows the project's coding standards
- [x] I have updated the documentation accordingly
- [x] I have updated the changelog
- [x] I have checked for and resolved any merge conflicts
- [x] I have confirmed the correct merge strategy will be used (see Branch Type above)
- [x] I have updated CREDITS.md if necessary