### PR TITLE
refactor: rebuild package for the 1.0 release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "bootstrap-sha": "c11aff902f05e680b8a48ebb3f9b2de43af7c54b",
+  "bootstrap-sha": "487491ad4859cd46941cccf543147edb838aba43",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "changelog-sections": [


### PR DESCRIPTION
Forces the first release candidate.

- Sets `Release-As: 1.0.0-rc.1` (via this commit's footer) so release-please cuts `v1.0.0-rc.1` instead of a patch bump.
- Bumps `bootstrap-sha` to the #278 squash so the rc.1 changelog is a single "Changed" line for the refactor, dropping the stray #270 entry.