### PR TITLE
fix: only offer the focal point picker for croppable attachments

### DIFF
--- a/specs/focal-point.md
+++ b/specs/focal-point.md
@@ -38,7 +38,10 @@ honoring, and cropping. The explicit per-call attribute is independent of the fl
 **Picker eligibility.** The picker is offered — and focal saves accepted — only for attachments
 the registered WordPress image editor can process, probed with `wp_image_editor_supports()`.
 This excludes SVG. Because the probe reflects the server's GD/Imagick build, eligibility is
-capability-dependent: a host without AVIF support shows no picker on AVIF uploads.
+capability-dependent: a host without AVIF support shows no picker on AVIF uploads. A first gate,
+`wp_attachment_is_image()`, constrains eligibility to `image/*` mime types; it is deliberately
+retained rather than replaced by the editor probe, because `wp_image_editor_supports()` alone
+returns `true` for `application/pdf` on an Imagick build with a Ghostscript delegate.
 
 Scenario: computes a crop window centred on the focal point
   Given an original larger than a square crop target and a focal point of 25/75

--- a/specs/focal-point.md
+++ b/specs/focal-point.md
@@ -14,7 +14,8 @@ the image into a box, so the two mechanisms split by size type:
 - **Hard-crop registered sizes** — the generated subsize file is physically re-cropped around the
   focal point, sourced from the original. Focal-correct across the whole `srcset`, no CSS.
 - **CSS `object-fit: cover; object-position: x% y%`** — emitted only where cover is in play: an
-  explicit per-call `focal-point` request, the crop-size upscale-too-small fallback, and SVG.
+  explicit per-call `focal-point` request and the crop-size upscale-too-small fallback. SVG is
+  excluded from the feature and never receives focal styling.
 - **Non-crop sizes without explicit cover** — no focal effect.
 
 **Precedence.** CSS position uses `explicit per-call coords → attachment metadata → center`.
@@ -33,6 +34,11 @@ render re-crops. A crop failure trips a per-attachment fuse and the image serves
 
 **Configuration.** `config('sproutset.focal_point')` (default `true`) gates the picker, metadata
 honoring, and cropping. The explicit per-call attribute is independent of the flag.
+
+**Picker eligibility.** The picker is offered — and focal saves accepted — only for attachments
+the registered WordPress image editor can process, probed with `wp_image_editor_supports()`.
+This excludes SVG. Because the probe reflects the server's GD/Imagick build, eligibility is
+capability-dependent: a host without AVIF support shows no picker on AVIF uploads.
 
 Scenario: computes a crop window centred on the focal point
   Given an original larger than a square crop target and a focal point of 25/75
@@ -99,6 +105,16 @@ Scenario: saving the picker stores and clamps the focal point and invalidates cr
   When the attachment form is saved
   Then the coordinates are clamped and stored and the applied-marker is cleared
 
+Scenario: the picker is only offered for attachments the image editor can crop
+  Given an SVG attachment
+  When the attachment edit fields are built, and when a focal point save is posted for it
+  Then no focal point field is added and no coordinates are stored
+
+Scenario: SVG receives no focal styling
+  Given an SVG attachment with a stored focal point and an explicit per-call focal request
+  When the image is resolved
+  Then no style is produced
+
 ## Acceptance criteria
 
 | Scenario | Test |
@@ -116,3 +132,5 @@ Scenario: saving the picker stores and clamps the focal point and invalidates cr
 | an explicit per-call focal point overrides the stored one for CSS | `tests/Integration/WpImageResolverTest.php` → `test_explicit_coordinates_override_the_attachment_focal_point` |
 | the feature is inert when disabled | `tests/Integration/WpImageResolverTest.php` → `test_is_inert_when_the_feature_is_disabled`; `tests/Feature/FocalPointConfigTest.php` → `it('reflects a disabled focal point config flag')` |
 | saving the picker stores and clamps the focal point and invalidates crops | `tests/Integration/FocalPointMediaFieldTest.php` → `test_saves_and_clamps_the_focal_point_from_the_form`, `test_clears_the_applied_marker_when_the_focal_point_is_saved` |
+| the picker is only offered for attachments the image editor can crop | `tests/Integration/FocalPointMediaFieldTest.php` → `test_does_not_offer_the_picker_for_an_svg_attachment`, `test_ignores_a_focal_point_save_for_an_svg_attachment` |
+| SVG receives no focal styling | `tests/Integration/WpImageResolverTest.php` → `test_emits_no_focal_style_for_an_svg` |

--- a/src/Admin/FocalPointMediaField.php
+++ b/src/Admin/FocalPointMediaField.php
@@ -58,6 +58,10 @@ final class FocalPointMediaField
             return $post;
         }
 
+        if (! $this->isCroppable($id)) {
+            return $post;
+        }
+
         FocalPointMeta::write($id, (float) $attachment['sproutset_focal_x'], (float) $attachment['sproutset_focal_y']);
         FocalPointMeta::clearApplied($id);
 

--- a/src/Admin/FocalPointMediaField.php
+++ b/src/Admin/FocalPointMediaField.php
@@ -23,7 +23,7 @@ final class FocalPointMediaField
      */
     public function addField(array $formFields, WP_Post $attachment): array
     {
-        if (! wp_attachment_is_image($attachment->ID)) {
+        if (! $this->isCroppable($attachment->ID)) {
             return $formFields;
         }
 
@@ -74,6 +74,17 @@ final class FocalPointMediaField
 
         echo $this->styles();
         echo $this->script();
+    }
+
+    private function isCroppable(int $attachmentId): bool
+    {
+        if (! wp_attachment_is_image($attachmentId)) {
+            return false;
+        }
+
+        $mime = get_post_mime_type($attachmentId);
+
+        return $mime !== false && wp_image_editor_supports(['mime_type' => $mime]);
     }
 
     private function markup(int $attachmentId, string $preview, float $x, float $y): string

--- a/src/Images/WpImageResolver.php
+++ b/src/Images/WpImageResolver.php
@@ -55,7 +55,7 @@ final readonly class WpImageResolver implements ImageResolver
             width: null,
             height: null,
             alt: $this->alt($request),
-            style: FocalPointPosition::forCover($this->cssFocal($request), $request->focalPoint),
+            style: null,
             isSvg: true,
         );
     }

--- a/tests/Integration/FocalPointMediaFieldTest.php
+++ b/tests/Integration/FocalPointMediaFieldTest.php
@@ -64,4 +64,14 @@ final class FocalPointMediaFieldTest extends IntegrationTestCase
         $this->assertStringNotContainsString('{{ID}}', $html);
         $this->assertStringContainsString('draggable="false"', $html);
     }
+
+    public function test_does_not_offer_the_picker_for_an_svg_attachment(): void
+    {
+        $id = $this->seedAttachment('example.svg');
+        $attachment = get_post($id);
+
+        $fields = (new FocalPointMediaField)->addField([], $attachment);
+
+        $this->assertArrayNotHasKey('sproutset_focal_point', $fields);
+    }
 }

--- a/tests/Integration/FocalPointMediaFieldTest.php
+++ b/tests/Integration/FocalPointMediaFieldTest.php
@@ -74,4 +74,16 @@ final class FocalPointMediaFieldTest extends IntegrationTestCase
 
         $this->assertArrayNotHasKey('sproutset_focal_point', $fields);
     }
+
+    public function test_ignores_a_focal_point_save_for_an_svg_attachment(): void
+    {
+        $id = $this->seedAttachment('example.svg');
+
+        (new FocalPointMediaField)->saveField(
+            ['ID' => $id],
+            ['sproutset_focal_x' => '25', 'sproutset_focal_y' => '75'],
+        );
+
+        $this->assertNull(FocalPointMeta::read($id));
+    }
 }

--- a/tests/Integration/WpImageResolverTest.php
+++ b/tests/Integration/WpImageResolverTest.php
@@ -244,4 +244,16 @@ final class WpImageResolverTest extends IntegrationTestCase
 
         $this->assertSame([], FocalPointMeta::appliedAt($id));
     }
+
+    public function test_emits_no_focal_style_for_an_svg(): void
+    {
+        $id = $this->seedAttachment('example.svg');
+        FocalPointMeta::write($id, 25.0, 75.0);
+
+        $resolved = $this->focalResolver(true)->resolve($this->focalRequest($id, 'large', true, 10.0, 20.0));
+
+        $this->assertNotNull($resolved);
+        $this->assertTrue($resolved->isSvg);
+        $this->assertNull($resolved->style);
+    }
 }


### PR DESCRIPTION
## Summary

The focal point picker was appearing on SVG attachments in the Media Library. It now appears only on attachments the WordPress image editor can actually crop, and SVG is removed from the focal point feature entirely.

**Root cause.** `FocalPointMediaField::addField()` gated on `wp_attachment_is_image()`, which is a mime-**prefix** test rather than an extension allowlist. Core's `wp_attachment_is()` returns early on `str_starts_with($post->post_mime_type, 'image/')`, and its `jpg|jpeg|jpe|gif|png|webp|avif|heic` allowlist sits behind an `if ('import' !== $post->post_mime_type)` return, making it unreachable for normal attachments. So it returns `true` for `image/svg+xml`, and also for `image/x-icon` and `image/tiff`.

**Changes.**

- `FocalPointMediaField::isCroppable()` pairs `wp_attachment_is_image()` with `wp_image_editor_supports(['mime_type' => ...])`, gating both the render path (`addField`) and the save path (`saveField`). The save-path guard runs last, after the `isset`/`is_numeric` checks, so its database lookup only happens for requests carrying focal coordinates.
- `WpImageResolver::resolveSvg()` returns `style: null`, so SVG no longer emits `object-fit`/`object-position`, including for explicit per-call `focal-point` attributes. `Image::htmlAttributesFor()` already drops a null style via `array_filter()`, so no component change was needed.
- `specs/focal-point.md` updated: SVG removed from the cover-context list, plus a new "Picker eligibility" section and two scenarios with acceptance-criteria rows.

**Why `wp_attachment_is_image()` is retained rather than replaced.** On a server with Imagick plus a Ghostscript delegate, `wp_image_editor_supports(['mime_type' => 'application/pdf'])` returns `true`. Without the `image/*` constraint the picker would render on PDF attachments. This rationale is recorded in the spec so it is not removed as redundant later.

**Deliberate scope decisions.**

- `WpAttachmentRepository::find()` keeps its existing `wp_attachment_is_image()` check. Extending the capability probe there would change *rendering* rather than admin UI: a `.tiff` on a GD-only server would stop rendering entirely instead of merely losing its picker.
- `'methods' => ['crop']` is omitted from the probe args, having been measured redundant since both editor implementations provide `crop()`.
- Picker visibility is now server-capability dependent, so a host without AVIF support shows no picker on AVIF uploads. This is accepted and documented, being the direct consequence of gating on real handler capability.

Focal coordinates already stored against SVG attachments become inert. No migration is needed.

## Related issue

<!-- none -->

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `perf:`, `revert:`)
- [x] Changes are focused on a single concern
- [x] I have tested these changes