### PR TITLE
ci: keep release-please bumping the rc series

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,7 +12,10 @@
   ],
   "packages": {
     ".": {
-      "release-type": "simple"
+      "release-type": "simple",
+      "versioning": "prerelease",
+      "prerelease": true,
+      "prerelease-type": "rc"
     }
   }
 }


### PR DESCRIPTION
## Summary

Release PR #282 came out as `1.0.1-rc.1` instead of `1.0.0-rc.2`. The cause is that `release-please-config.json` never set a `versioning` strategy, so it used the default one. Default `PatchVersionUpdate` increments `patch` and carries the existing prerelease string through untouched, so `1.0.0-rc.1` plus three `fix:` commits became `1.0.1-rc.1`. It has no notion of an rc counter.

This switches the package to the prerelease strategy, which bumps the trailing number of the prerelease part when one is present (`rc.1` to `rc.2`). All three keys are required together:

- `versioning: prerelease` selects the strategy.
- `prerelease: true` keeps the suffix. With it set to `false` the strategy strips the prerelease part and would cut a stable `1.0.0`.
- `prerelease-type: rc` is the suffix used when the current version has no prerelease part.

While major and minor stay at `1.0`, every commit type now stays inside the RC series: `fix:` gives `rc.2`, and so do `feat:` and breaking changes.

Once this is on `main`, release-please recomputes against the manifest (`1.0.0-rc.1`) and force-updates the release branch, so #282 should retitle to `chore(main): release 1.0.0-rc.2`.

Note for later: this config does not cut a stable release on its own. To promote, land a commit on `main` with a `Release-As: 1.0.0` footer, then drop these three keys. Otherwise the next `fix:` after `1.0.0` would produce `1.0.1-rc`, since `prerelease-type` gets applied to versions that have no prerelease part.

## Related issue

n/a

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `perf:`, `revert:`)
- [x] Changes are focused on a single concern
- [x] I have tested these changes

Verification is by inspection of release-please's `versioning-strategies/prerelease.ts`, since the bump only runs in the workflow: with `preRelease` set, `PrereleasePatchVersionUpdate` keeps major/minor/patch and increments the last number in the suffix. The config remains valid JSON against its schema.