### PR TITLE
ci: derive the wp-phpunit constraint from the downloaded WordPress core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,15 +97,17 @@ jobs:
           fi
 
       # The bundled WordPress test suite (wp-phpunit) is versioned per WordPress
-      # release; align it with the core under test so the suite matches its APIs.
+      # release; align it with the core that was actually downloaded so the suite
+      # matches its APIs even as `latest` moves on to a new major series.
       - name: Align the WordPress test suite to the series
         run: |
-          if [ "${{ matrix.wp }}" = "latest" ]; then
-            CONSTRAINT="^7.0"
-          else
-            CONSTRAINT="${{ matrix.wp }}.*"
+          SERIES=$(wp core version --path=/tmp/wordpress | cut -d. -f1,2)
+          if [ -z "${SERIES}" ]; then
+            echo "Could not determine the WordPress version under test" >&2
+            exit 1
           fi
-          composer require --working-dir=tests/Integration --dev --with-all-dependencies --no-interaction "wp-phpunit/wp-phpunit:${CONSTRAINT}"
+          echo "Aligning wp-phpunit to WordPress ${SERIES}"
+          composer require --working-dir=tests/Integration --dev --with-all-dependencies --no-interaction "wp-phpunit/wp-phpunit:${SERIES}.*"
 
       - name: Run the drift lane
         env:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Modern responsive image management for projects using the Roots Acorn framework.
 ## Requirements
 
 - PHP ^8.4
-- WordPress 6.7+
+- WordPress 6.7+ (tested up to 7.1)
 - Roots Acorn ^6.2
 
 ## Installation


### PR DESCRIPTION
Follow-up to a WordPress 7.1 compatibility check. The package itself needed no changes: the drift lane already runs green against real WP 7.1 (58 tests, 158 assertions), and the 7.1 field guide lists no deprecation or removal touching any API Sproutset uses. This PR fixes the one real problem the check surfaced, which is in the harness rather than the library.

## The problem

The `latest` integration lane hardcoded the wp-phpunit constraint:

```yaml
if [ "${{ matrix.wp }}" = "latest" ]; then
  CONSTRAINT="^7.0"
```

That holds only while `latest` stays inside the 7.x series. Once WordPress 8.0 ships, the lane downloads 8.0 core and pairs it with the 7.x test suite. The job would either break confusingly or, worse, pass while testing a mismatched pair. Either way the drift lane stops detecting drift, which is the only thing it exists to do.

## The change

Read the series back off the core that was actually downloaded, and use it for both lanes:

```yaml
SERIES=$(wp core version --path=/tmp/wordpress | cut -d. -f1,2)
```

`wp core version` is annotated `@when before_wp_load` and reads `wp-includes/version.php` directly, so it works on a bare `wp core download` with no wp-config and no database, which is exactly the state of `/tmp/wordpress` at that point in the job.

The empty-string guard matters: without it, a failed lookup would fall through to `wp-phpunit:.*` and quietly install whatever Composer felt like.

The pinned `6.7` lane is unaffected in behaviour, it just takes the same code path now instead of its own branch.

## Verification

Checked before pushing:

- YAML parses, the integration job still has its 6 steps.
- Constraint derivation: `7.1` gives `7.1.*`, `6.7.2` gives `6.7.*`, `6.7` gives `6.7.*`.
- Both resolve to real packagist releases (`7.1.0` and `6.7.7`), so neither lane loses its suite.

The rest is what CI proves on this PR. Both integration lanes need to go green.

## Also

README requirements now read `WordPress 6.7+ (tested up to 7.1)`.

No PHP changed, so lint, types and Pest are untouched. `ci:` and `docs:` are not in `changelog-sections`, so this is changelog-silent and does not move the version.
