### PR TITLE
feat: lift WordPress srcset 2048px ceiling for configured retina widths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ Thumbs.db
 /.vscode/
 *.swp
 
+# Local, machine-specific Claude instructions
+/CLAUDE.local.md
+
 # PHPUnit
 /.phpunit.cache/
 /tests/Integration/vendor/

--- a/specs/image-size-registration.md
+++ b/specs/image-size-registration.md
@@ -10,6 +10,12 @@ Normalization coerces `width`/`height` to non-negative integers and `crop` to a 
 
 Registration strips every currently-registered subsize (`remove_image_size()` over `wp_get_registered_image_subsizes()`), then registers each normalized entry. Because this runs on `after_setup_theme` at priority 10, the "complete roster" holds for sizes registered at priority ≤ 10; sizes other plugins register later still apply. WordPress core sizes (thumbnail/medium/medium_large/large) are option-driven and survive the strip unless the config overrides them by name. The package ships those four as defaults so a fresh install keeps working.
 
+## Srcset width ceiling
+
+WordPress' `wp_calculate_image_srcset()` drops any candidate wider than `apply_filters('max_srcset_image_width', 2048, $size_array)` unless that exact width is one of the requested size's dimensions. Configured `@Nx` variants routinely exceed 2048px (a `large@3x` at 3072, or any base above 2048), so the files `OnDemandSizeGenerator` produces for them would be generated yet silently excluded from the emitted srcset.
+
+`SrcsetWidthLimit`, registered on the boot path from the same `config('sproutset.image_sizes')` roster, lifts the ceiling to the largest configured width. It reads the normalized roster (base sizes and their `@Nx` variants) and computes the largest width. When that exceeds WordPress' 2048px default, it registers a `max_srcset_image_width` filter returning `max($currentValue, $largestConfiguredWidth)` — so a higher value another plugin already set is never lowered. When no configured width exceeds the default, no filter is registered and srcset output stays byte-identical to WordPress' behavior.
+
 ## Scenarios
 
 ```gherkin
@@ -62,6 +68,41 @@ Scenario: Normalizes the shipped default config
   Given the shipped config('sproutset.image_sizes') defaults
   When the config is normalized
   Then it yields the four base sizes plus @0.5x and @2x variants for medium_large and large, with large@2x sized 2048x2048
+
+Scenario: Derives the ceiling from the largest configured width
+  Given a config whose largest variant is wider than the 2048px default
+  When the srcset width ceiling is computed
+  Then it equals that largest variant width
+
+Scenario: Counts a base size that itself exceeds the default
+  Given a config with a base size wider than the 2048px default and no variants
+  When the srcset width ceiling is computed
+  Then it equals that base size width
+
+Scenario: Yields no ceiling when the default already covers every width
+  Given a config whose every width is at or below the 2048px default
+  When the srcset width ceiling is computed
+  Then no ceiling is produced
+
+Scenario: Yields no ceiling for an empty config
+  Given an empty config
+  When the srcset width ceiling is computed
+  Then no ceiling is produced
+
+Scenario: Raises the live max_srcset_image_width filter
+  Given a registered ceiling for a config with a variant wider than the default
+  When max_srcset_image_width is filtered from its 2048 default
+  Then it returns the largest configured width
+
+Scenario: Never lowers a ceiling another plugin raised higher
+  Given a registered ceiling below a value another plugin already set
+  When max_srcset_image_width is filtered from that higher value
+  Then it returns the higher value unchanged
+
+Scenario: Leaves the filter untouched when no width exceeds the default
+  Given a config whose every width is at or below the default
+  When max_srcset_image_width is filtered from its 2048 default
+  Then it returns 2048
 ```
 
 ## Acceptance criteria
@@ -80,3 +121,10 @@ Each scenario above maps 1:1 to a test:
 | `Ships default image sizes` | `tests/Feature/ImageSizeRegistrationTest.php` → `it('ships the default image sizes in config')` |
 | `Registrar resolves from the container` | `tests/Feature/ImageSizeRegistrationTest.php` → `it('resolves the image size registrar from the container')` |
 | `Normalizes the shipped default config` | `tests/Feature/ImageSizeRegistrationTest.php` → `it('normalizes the shipped default config into base sizes and variants')` |
+| `Derives the ceiling from the largest configured width` | `tests/Unit/SrcsetWidthLimitTest.php` → `it('raises the ceiling to the largest variant wider than the WordPress default')` |
+| `Counts a base size that itself exceeds the default` | `tests/Unit/SrcsetWidthLimitTest.php` → `it('considers a base size that itself exceeds the default')` |
+| `Yields no ceiling when the default already covers every width` | `tests/Unit/SrcsetWidthLimitTest.php` → `it('leaves the default in place when no configured width exceeds it')` |
+| `Yields no ceiling for an empty config` | `tests/Unit/SrcsetWidthLimitTest.php` → `it('returns null for an empty config')` |
+| `Raises the live max_srcset_image_width filter` | `tests/Integration/SrcsetWidthLimitTest.php` → `test_raises_the_srcset_ceiling_to_the_largest_configured_width` |
+| `Never lowers a ceiling another plugin raised higher` | `tests/Integration/SrcsetWidthLimitTest.php` → `test_never_lowers_a_ceiling_another_plugin_raised_higher` |
+| `Leaves the filter untouched when no width exceeds the default` | `tests/Integration/SrcsetWidthLimitTest.php` → `test_leaves_the_default_untouched_when_no_width_exceeds_it` |

--- a/src/Images/ImageSizeConfigNormalizer.php
+++ b/src/Images/ImageSizeConfigNormalizer.php
@@ -8,7 +8,7 @@ final class ImageSizeConfigNormalizer
 {
     /**
      * @param  array<array-key, mixed>  $rawConfig
-     * @return array<string, array{width: int, height: int, crop: bool}>
+     * @return array<string, array{width: int<0, max>, height: int<0, max>, crop: bool}>
      */
     public function normalize(array $rawConfig): array
     {
@@ -31,8 +31,8 @@ final class ImageSizeConfigNormalizer
 
             foreach ($this->multipliers($sizeConfig['srcset'] ?? null) as $multiplier) {
                 $normalized[$sizeName.'@'.$multiplier.'x'] = [
-                    'width' => $width > 0 ? (int) ($width * $multiplier) : 0,
-                    'height' => $height > 0 ? (int) ($height * $multiplier) : 0,
+                    'width' => $width > 0 ? max(0, (int) ($width * $multiplier)) : 0,
+                    'height' => $height > 0 ? max(0, (int) ($height * $multiplier)) : 0,
                     'crop' => $crop,
                 ];
             }
@@ -61,6 +61,9 @@ final class ImageSizeConfigNormalizer
         return $multipliers;
     }
 
+    /**
+     * @return int<0, max>
+     */
     private function toNonNegativeInt(mixed $value): int
     {
         return is_numeric($value) ? max(0, (int) $value) : 0;

--- a/src/Images/SrcsetWidthLimit.php
+++ b/src/Images/SrcsetWidthLimit.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webkinder\Sproutset\Images;
+
+final readonly class SrcsetWidthLimit
+{
+    private const int WP_DEFAULT_MAX_SRCSET_WIDTH = 2048;
+
+    public function __construct(private ImageSizeConfigNormalizer $normalizer) {}
+
+    /**
+     * @param  array<array-key, mixed>  $rawConfig
+     */
+    public function ceilingFor(array $rawConfig): ?int
+    {
+        $widths = array_column($this->normalizer->normalize($rawConfig), 'width');
+        $largest = $widths === [] ? 0 : max($widths);
+
+        return $largest > self::WP_DEFAULT_MAX_SRCSET_WIDTH ? $largest : null;
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $rawConfig
+     */
+    public function register(array $rawConfig): void
+    {
+        $ceiling = $this->ceilingFor($rawConfig);
+
+        if ($ceiling === null) {
+            return;
+        }
+
+        add_filter('max_srcset_image_width', static function (mixed $currentMax) use ($ceiling): int {
+            $current = is_numeric($currentMax) ? (int) $currentMax : 0;
+
+            return max($current, $ceiling);
+        });
+    }
+}

--- a/src/Images/WpImageResolver.php
+++ b/src/Images/WpImageResolver.php
@@ -137,9 +137,9 @@ final readonly class WpImageResolver implements ImageResolver
             return null;
         }
 
-        $targetWidth = is_numeric($spec['width'] ?? null) ? (int) $spec['width'] : 0;
-        $targetHeight = is_numeric($spec['height'] ?? null) ? (int) $spec['height'] : 0;
-        $crop = (bool) ($spec['crop'] ?? false);
+        $targetWidth = (int) $spec['width'];
+        $targetHeight = (int) $spec['height'];
+        $crop = (bool) $spec['crop'];
 
         return PresentedDimensions::forSource(
             $targetWidth,
@@ -206,8 +206,8 @@ final readonly class WpImageResolver implements ImageResolver
     private function urlToPath(string $url): ?string
     {
         $uploads = wp_get_upload_dir();
-        $baseUrl = is_string($uploads['baseurl'] ?? null) ? $uploads['baseurl'] : '';
-        $baseDir = is_string($uploads['basedir'] ?? null) ? $uploads['basedir'] : '';
+        $baseUrl = $uploads['baseurl'];
+        $baseDir = $uploads['basedir'];
 
         if ($baseUrl === '' || ! str_starts_with($url, $baseUrl)) {
             return null;
@@ -219,8 +219,8 @@ final readonly class WpImageResolver implements ImageResolver
     private function pathToUrl(string $path): ?string
     {
         $uploads = wp_get_upload_dir();
-        $baseDir = is_string($uploads['basedir'] ?? null) ? $uploads['basedir'] : '';
-        $baseUrl = is_string($uploads['baseurl'] ?? null) ? $uploads['baseurl'] : '';
+        $baseDir = $uploads['basedir'];
+        $baseUrl = $uploads['baseurl'];
 
         if ($baseDir === '' || ! str_starts_with($path, $baseDir)) {
             return null;

--- a/src/SproutsetServiceProvider.php
+++ b/src/SproutsetServiceProvider.php
@@ -22,6 +22,7 @@ use Webkinder\Sproutset\Images\ImageResolver;
 use Webkinder\Sproutset\Images\ImageSizeRegistrar;
 use Webkinder\Sproutset\Images\MediaSettingsLock;
 use Webkinder\Sproutset\Images\OnDemandSizeGenerator;
+use Webkinder\Sproutset\Images\SrcsetWidthLimit;
 use Webkinder\Sproutset\Images\WpImageResolver;
 use Webkinder\Sproutset\View\Components\Image;
 
@@ -62,6 +63,7 @@ class SproutsetServiceProvider extends PackageServiceProvider
 
         $this->app->make(CoreImageSizeOptions::class)->register($this->imageSizesConfig());
         $this->app->make(MediaSettingsLock::class)->register($this->imageSizesConfig());
+        $this->app->make(SrcsetWidthLimit::class)->register($this->imageSizesConfig());
 
         add_action('delete_attachment', function (int $attachmentId): void {
             $this->app->make(AvifCleanup::class)->forget($attachmentId);

--- a/tests/Integration/SrcsetWidthLimitTest.php
+++ b/tests/Integration/SrcsetWidthLimitTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webkinder\Sproutset\Tests\Integration;
+
+use Webkinder\Sproutset\Images\ImageSizeConfigNormalizer;
+use Webkinder\Sproutset\Images\SrcsetWidthLimit;
+
+final class SrcsetWidthLimitTest extends IntegrationTestCase
+{
+    private function limit(): SrcsetWidthLimit
+    {
+        return new SrcsetWidthLimit(new ImageSizeConfigNormalizer);
+    }
+
+    public function test_raises_the_srcset_ceiling_to_the_largest_configured_width(): void
+    {
+        $this->limit()->register([
+            'large' => ['width' => 1024, 'height' => 1024, 'crop' => false, 'srcset' => [2, 3]],
+        ]);
+
+        $this->assertSame(3072, apply_filters('max_srcset_image_width', 2048, [1024, 1024]));
+    }
+
+    public function test_never_lowers_a_ceiling_another_plugin_raised_higher(): void
+    {
+        $this->limit()->register([
+            'large' => ['width' => 1024, 'height' => 1024, 'crop' => false, 'srcset' => [3]],
+        ]);
+
+        $this->assertSame(4000, apply_filters('max_srcset_image_width', 4000, [1024, 1024]));
+    }
+
+    public function test_leaves_the_default_untouched_when_no_width_exceeds_it(): void
+    {
+        $this->limit()->register([
+            'large' => ['width' => 1024, 'height' => 1024, 'crop' => false, 'srcset' => [2]],
+        ]);
+
+        $this->assertSame(2048, apply_filters('max_srcset_image_width', 2048, [1024, 1024]));
+    }
+}

--- a/tests/Unit/SrcsetWidthLimitTest.php
+++ b/tests/Unit/SrcsetWidthLimitTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Webkinder\Sproutset\Images\ImageSizeConfigNormalizer;
+use Webkinder\Sproutset\Images\SrcsetWidthLimit;
+
+function srcsetWidthLimit(): SrcsetWidthLimit
+{
+    return new SrcsetWidthLimit(new ImageSizeConfigNormalizer);
+}
+
+it('raises the ceiling to the largest variant wider than the WordPress default', function (): void {
+    $ceiling = srcsetWidthLimit()->ceilingFor([
+        'large' => ['width' => 1024, 'height' => 1024, 'crop' => false, 'srcset' => [2, 3]],
+    ]);
+
+    expect($ceiling)->toBe(3072);
+});
+
+it('leaves the default in place when no configured width exceeds it', function (): void {
+    $ceiling = srcsetWidthLimit()->ceilingFor([
+        'large' => ['width' => 1024, 'height' => 1024, 'crop' => false, 'srcset' => [2]],
+    ]);
+
+    expect($ceiling)->toBeNull();
+});
+
+it('considers a base size that itself exceeds the default', function (): void {
+    $ceiling = srcsetWidthLimit()->ceilingFor([
+        'hero' => ['width' => 2560, 'height' => 0, 'crop' => false],
+    ]);
+
+    expect($ceiling)->toBe(2560);
+});
+
+it('returns null for an empty config', function (): void {
+    expect(srcsetWidthLimit()->ceilingFor([]))->toBeNull();
+});


### PR DESCRIPTION
## Problem
WordPress' `wp_calculate_image_srcset()` drops any srcset candidate wider than `max_srcset_image_width` (default **2048px**) unless the width matches the requested size exactly. Sproutset's `@Nx` variant feature generates files above 2048px, which were then silently excluded from the emitted srcset — wasted generation and broken retina intent above 2048.

## Change
`SrcsetWidthLimit` reads the normalized `image_sizes` roster on boot and, when the largest configured width exceeds 2048, registers a `max_srcset_image_width` filter returning `max(current, largest)`.

- Scoped: registered only when a configured width actually exceeds 2048, so sites without large variants stay byte-identical to stock WP.
- `max(current, …)` never lowers a value another plugin set higher.

## Tests
Unit + integration (real WP) cover ceiling computation and live filter behavior, mapped 1:1 in `specs/image-size-registration.md`.